### PR TITLE
Fix Compilation Issue with Xcode 9

### DIFF
--- a/SwiftMonkey/MonkeyXCTest.swift
+++ b/SwiftMonkey/MonkeyXCTest.swift
@@ -34,7 +34,7 @@ extension Monkey {
                 let alert = application.alerts.element(boundBy: i)
                 let buttons = alert.descendants(matching: .button)
                 XCTAssertNotEqual(buttons.count, 0, "No buttons in alert")
-                let index = UInt(self!.r.randomUInt32() % UInt32(buttons.count))
+                let index = self!.r.randomInt(lessThan: buttons.count)
                 let button = buttons.element(boundBy: index)
                 button.tap()
             }


### PR DESCRIPTION
Random number type needs to be `Int` not `Uint`, This way `element(boundBy:)` can accept it without any compilation error.