### PR TITLE
Fixing issue where memory would bloat in UITest runner when running o…

### DIFF
--- a/SwiftMonkey/Monkey.swift
+++ b/SwiftMonkey/Monkey.swift
@@ -217,23 +217,24 @@ public class Monkey {
      and not in some other app that the Monkey randomly opened.
      */
     func actInForeground(_ action: @escaping ActionClosure) -> ActionClosure {
-        return {
-            guard #available(iOS 9.0, *) else {
-                action()
-                return
-            }
-            let closure: ActionClosure = {
-                if XCUIApplication().state != .runningForeground {
-                    XCUIApplication().activate()
-                }
-                action()
-            }
-            if Thread.isMainThread {
-                closure()
-            } else {
-                DispatchQueue.main.async(execute: closure)
-            }
-        }
+		guard #available(iOS 9.0, *) else {
+			return action
+		}
+		
+		let app = XCUIApplication()
+		let closure: ActionClosure = {
+			if app.state != .runningForeground {
+				app.activate()
+			}
+			action()
+		}
+		return {
+			if Thread.isMainThread {
+				closure()
+			} else {
+				DispatchQueue.main.async(execute: closure)
+			}
+		}
     }
 
     /**


### PR DESCRIPTION
…n device.  It seemed to have been caused by XCUIApplication() getting called multiple times per execution of an action.  Its now only retained once per action. Resolves #23