### PR TITLE
fix: use Public API on Xcode10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,36 +102,36 @@ the input event generation. Here is a simple example:
 
 ````swift
 func testMonkey() {
-    let application = XCUIApplication()
+        let application = XCUIApplication()
 
-    // Workaround for bug in Xcode 7.3. Snapshots are not properly updated
-    // when you initially call app.frame, resulting in a zero-sized rect.
-    // Doing a random query seems to update everything properly.
-    // TODO: Remove this when the Xcode bug is fixed!
-    _ = application.descendants(matching: .any).element(boundBy: 0).frame
+        // Initialise the monkey tester with the current device
+        // frame. Giving an explicit seed will make it generate
+        // the same sequence of events on each run, and leaving it
+        // out will generate a new sequence on each run.
+        let monkey = Monkey(frame: application.frame)
+        //let monkey = Monkey(seed: 123, frame: application.frame)
 
-    // Initialise the monkey tester with the current device
-    // frame. Giving an explicit seed will make it generate
-    // the same sequence of events on each run, and leaving it
-    // out will generate a new sequence on each run.
-    let monkey = Monkey(frame: application.frame)
-    //let monkey = Monkey(seed: 123, frame: application.frame)
+        // Add actions for the monkey to perform. We just use a
+        // default set of actions for this, which is usually enough.
+        // Use either one of these but maybe not both.
 
-    // Add actions for the monkey to perform. We just use a
-    // default set of actions for this, which is usually enough.
-    // Use either one of these, but maybe not both.
-    // XCTest private actions seem to work better at the moment.
-    // UIAutomation actions seem to work only on the simulator.
-    monkey.addDefaultXCTestPrivateActions()
-    //monkey.addDefaultUIAutomationActions()
+        // XCTest private actions seem to work better at the moment.
+        // before Xcode 10.1, you can use
+        // monkey.addDefaultXCTestPrivateActions()
 
-    // Occasionally, use the regular XCTest functionality
-    // to check if an alert is shown, and click a random
-    // button on it.
-    monkey.addXCTestTapAlertAction(interval: 100, application: application)
+        // after Xcode 10.1 We can only use public API
+        monkey.addDefaultXCTestPublicActions()
 
-    // Run the monkey test indefinitely.
-    monkey.monkeyAround()
+        // UIAutomation actions seem to work only on the simulator.
+        //monkey.addDefaultUIAutomationActions()
+
+        // Occasionally, use the regular XCTest functionality
+        // to check if an alert is shown, and click a random
+        // button on it.
+        monkey.addXCTestTapAlertAction(interval: 100, application: application)
+
+        // Run the monkey test indefinitely.
+        monkey.monkeyAround()
 }
 ````
 

--- a/SwiftMonkey/MonkeyXCTest.swift
+++ b/SwiftMonkey/MonkeyXCTest.swift
@@ -40,4 +40,80 @@ extension Monkey {
             }
         }
     }
+    
+    
+    public func addDefaultXCTestPublicActions() {
+        addXCTestPublicTapAction(weight: 25)
+        addXCTestPublicLongPressAction(weight: 1)
+        addXCTestPublicDragAction(weight: 1)
+    }
+    
+    /**
+     Add an action that generates a tap, with a possibility for
+     multiple taps with multiple fingers, using the private
+     XCTest API.
+     
+     - parameter weight: The relative probability of this
+     event being generated. Can be any value larger than
+     zero. Probabilities will be normalised to the sum
+     of all relative probabilities.
+     - parameter multipleTouchProbability: Probability that
+     the tap event will use multiple fingers. Between 0 and 1.
+     */
+    public func addXCTestPublicTapAction(weight: Double,
+                                   multipleTouchProbability: Double = 0.05) {
+        addAction(weight: weight) { [weak self] in
+            let locations: [CGPoint]
+            if self!.r.randomDouble() < multipleTouchProbability {
+                let numberOfTouches = Int(self!.r.randomUInt32() % 3) + 2
+                let rect = self!.randomRect()
+                locations = (1...numberOfTouches).map { _ in
+                    self!.randomPoint(inRect: rect)
+                }
+            } else {
+                locations = [ self!.randomPoint() ]
+            }
+            let app = XCUIApplication()
+            let coordinate = app.coordinate(withNormalizedOffset: CGVector(dx: locations[0].x/(app.frame.maxX/2), dy: locations[0].y/(app.frame.maxY/2)))
+            coordinate.tap()
+        }
+    }
+    
+    /**
+     Add an action that generates a long press event
+     using the private XCTest API.
+     
+     - Parameter weight: The relative probability of this
+     event being generated. Can be any value larger than
+     zero. Probabilities will be normalised to the sum
+     of all relative probabilities.
+     */
+    public func addXCTestPublicLongPressAction(weight: Double) {
+        addAction(weight: weight) { [weak self] in
+            let point = self!.randomPoint()
+            let app = XCUIApplication()
+            let coordinate = app.coordinate(withNormalizedOffset: CGVector(dx: point.x/(app.frame.maxX/2), dy: point.y/(app.frame.maxY/2)))
+            coordinate.press(forDuration: 0.5)
+        }
+    }
+    
+    /**
+     Add an action that generates a drag event from one random
+     screen position to another using the private XCTest API.
+     
+     - Parameter weight: The relative probability of this
+     event being generated. Can be any value larger than
+     zero. Probabilities will be normalised to the sum
+     of all relative probabilities.
+     */
+    public func addXCTestPublicDragAction(weight: Double) {
+        addAction(weight: weight) { [weak self] in
+            let start = self!.randomPointAvoidingPanelAreas()
+            let end = self!.randomPoint()
+            let app = XCUIApplication()
+            let startCoordinate = app.coordinate(withNormalizedOffset: CGVector(dx: start.x/(app.frame.maxX/2), dy: start.y/(app.frame.maxY/2)))
+            let endCoordinate = app.coordinate(withNormalizedOffset: CGVector(dx: end.x/(app.frame.maxX/2), dy: end.y/(app.frame.maxY/2)))
+            startCoordinate.press(forDuration: 0.2, thenDragTo: endCoordinate)
+        }
+    }
 }

--- a/SwiftMonkey/MonkeyXCTest.swift
+++ b/SwiftMonkey/MonkeyXCTest.swift
@@ -15,7 +15,11 @@ import XCTest
 */
 @available(iOS 9.0, *)
 extension Monkey {
-
+    /// Generates a random `CGVector` inside the frame of the app.
+    public func randomOffset() -> CGVector {
+        let point = randomPoint()
+        return CGVector(dx: point.x, dy: point.y)
+    }
     /**
         Add an action that checks, at a fixed interval,
         if an alert is being displayed, and if so, selects
@@ -41,78 +45,56 @@ extension Monkey {
         }
     }
     
-    
-    public func addDefaultXCTestPublicActions() {
-        addXCTestPublicTapAction(weight: 25)
-        addXCTestPublicLongPressAction(weight: 1)
-        addXCTestPublicDragAction(weight: 1)
+    public func addDefaultXCTestPublicActions(app: XCUIApplication) {
+        addXCTestPublicTapAction(app: app, weight: 25)
+        addXCTestPublicLongPressAction(app: app, weight: 1)
+        addXCTestPublicDragAction(app: app, weight: 1)
     }
     
-    /**
-     Add an action that generates a tap, with a possibility for
-     multiple taps with multiple fingers, using the private
-     XCTest API.
-     
-     - parameter weight: The relative probability of this
-     event being generated. Can be any value larger than
-     zero. Probabilities will be normalised to the sum
-     of all relative probabilities.
-     - parameter multipleTouchProbability: Probability that
-     the tap event will use multiple fingers. Between 0 and 1.
-     */
-    public func addXCTestPublicTapAction(weight: Double,
-                                   multipleTouchProbability: Double = 0.05) {
-        addAction(weight: weight) { [weak self] in
-            let locations: [CGPoint]
-            if self!.r.randomDouble() < multipleTouchProbability {
-                let numberOfTouches = Int(self!.r.randomUInt32() % 3) + 2
-                let rect = self!.randomRect()
-                locations = (1...numberOfTouches).map { _ in
-                    self!.randomPoint(inRect: rect)
-                }
+    
+    /// Add an action that generates a tap, with a possibility for double taps, using the public XCTest API.
+    /// - Parameter app: The application proxy.
+    /// - Parameter weight: The relative probability of this event being generated. Can be any value larger than zero. Probabilities
+    /// will be normalised to the sum of all relative probabilities.
+    /// - Parameter doubleTapProbability: Probability that a double tap event is used. Between 0 and 1.
+    public func addXCTestPublicTapAction(app: XCUIApplication,
+                                         weight: Double,
+                                         doubleTapProbability: Double = 0.05) {
+        addAction(weight: weight) { [unowned self] in
+            let doubleTap = self.r.randomDouble() < doubleTapProbability
+            let coordinate = app.coordinate(withNormalizedOffset: .zero).withOffset(self.randomOffset())
+            
+            if doubleTap {
+                coordinate.doubleTap()
             } else {
-                locations = [ self!.randomPoint() ]
+                coordinate.tap()
             }
-            let app = XCUIApplication()
-            let coordinate = app.coordinate(withNormalizedOffset: CGVector(dx: locations[0].x/(app.frame.maxX/2), dy: locations[0].y/(app.frame.maxY/2)))
-            coordinate.tap()
         }
     }
     
-    /**
-     Add an action that generates a long press event
-     using the private XCTest API.
-     
-     - Parameter weight: The relative probability of this
-     event being generated. Can be any value larger than
-     zero. Probabilities will be normalised to the sum
-     of all relative probabilities.
-     */
-    public func addXCTestPublicLongPressAction(weight: Double) {
-        addAction(weight: weight) { [weak self] in
-            let point = self!.randomPoint()
-            let app = XCUIApplication()
-            let coordinate = app.coordinate(withNormalizedOffset: CGVector(dx: point.x/(app.frame.maxX/2), dy: point.y/(app.frame.maxY/2)))
+    
+    /// Add an action that generates a long press event using the public XCTest API.
+    /// - Parameter app: The application proxy.
+    /// - Parameter weight: The relative probability of this event being generated. Can be any value larger than zero. Probabilities
+    /// will be normalised to the sum of all relative probabilities.
+    public func addXCTestPublicLongPressAction(app: XCUIApplication,
+                                               weight: Double) {
+        addAction(weight: weight) { [unowned self] in
+            let coordinate = app.coordinate(withNormalizedOffset: .zero).withOffset(self.randomOffset())
             coordinate.press(forDuration: 0.5)
         }
     }
     
-    /**
-     Add an action that generates a drag event from one random
-     screen position to another using the private XCTest API.
-     
-     - Parameter weight: The relative probability of this
-     event being generated. Can be any value larger than
-     zero. Probabilities will be normalised to the sum
-     of all relative probabilities.
-     */
-    public func addXCTestPublicDragAction(weight: Double) {
-        addAction(weight: weight) { [weak self] in
-            let start = self!.randomPointAvoidingPanelAreas()
-            let end = self!.randomPoint()
-            let app = XCUIApplication()
-            let startCoordinate = app.coordinate(withNormalizedOffset: CGVector(dx: start.x/(app.frame.maxX/2), dy: start.y/(app.frame.maxY/2)))
-            let endCoordinate = app.coordinate(withNormalizedOffset: CGVector(dx: end.x/(app.frame.maxX/2), dy: end.y/(app.frame.maxY/2)))
+
+    /// Add an action that generates a drag event from one random screen position to another using the public XCTest API.
+    /// - Parameter app: The application proxy.
+    /// - Parameter weight: The relative probability of this event being generated. Can be any value larger than zero. Probabilities
+    /// will be normalised to the sum of all relative probabilities.
+    public func addXCTestPublicDragAction(app: XCUIApplication,
+                                          weight: Double) {
+        addAction(weight: weight) { [unowned self] in
+            let startCoordinate = app.coordinate(withNormalizedOffset: .zero).withOffset(self.randomOffset())
+            let endCoordinate = app.coordinate(withNormalizedOffset: .zero).withOffset(self.randomOffset())
             startCoordinate.press(forDuration: 0.2, thenDragTo: endCoordinate)
         }
     }

--- a/SwiftMonkeyExample/AppTests/MonkeyTests.swift
+++ b/SwiftMonkeyExample/AppTests/MonkeyTests.swift
@@ -39,7 +39,7 @@ class SwiftMonkeyExampleUITests: XCTestCase {
         // monkey.addDefaultXCTestPrivateActions()
         
         // after Xcode 10.1 We can only use public API
-        monkey.addDefaultXCTestPublicActions()
+        monkey.addDefaultXCTestPublicActions(app: application)
         
         // UIAutomation actions seem to work only on the simulator.
         //monkey.addDefaultUIAutomationActions()

--- a/SwiftMonkeyExample/AppTests/MonkeyTests.swift
+++ b/SwiftMonkeyExample/AppTests/MonkeyTests.swift
@@ -23,12 +23,6 @@ class SwiftMonkeyExampleUITests: XCTestCase {
     func testMonkey() {
         let application = XCUIApplication()
 
-        // Workaround for bug in Xcode 7.3. Snapshots are not properly updated
-        // when you initially call app.frame, resulting in a zero-sized rect.
-        // Doing a random query seems to update everything properly.
-        // TODO: Remove this when the Xcode bug is fixed!
-        _ = application.descendants(matching: .any).element(boundBy: 0).frame
-
         // Initialise the monkey tester with the current device
         // frame. Giving an explicit seed will make it generate
         // the same sequence of events on each run, and leaving it
@@ -39,11 +33,17 @@ class SwiftMonkeyExampleUITests: XCTestCase {
         // Add actions for the monkey to perform. We just use a
         // default set of actions for this, which is usually enough.
         // Use either one of these but maybe not both.
+        
         // XCTest private actions seem to work better at the moment.
+        // before Xcode 10.1, you can use
+        // monkey.addDefaultXCTestPrivateActions()
+        
+        // after Xcode 10.1 We can only use public API
+        monkey.addDefaultXCTestPublicActions()
+        
         // UIAutomation actions seem to work only on the simulator.
-        monkey.addDefaultXCTestPrivateActions()
         //monkey.addDefaultUIAutomationActions()
-
+        
         // Occasionally, use the regular XCTest functionality
         // to check if an alert is shown, and click a random
         // button on it.


### PR DESCRIPTION
Temporarily resolve the failure of the base gesture when xcode10.2. #75 #73