### PR TITLE
Fix seed issue in Random.swift init

### DIFF
--- a/SwiftMonkey/Random.swift
+++ b/SwiftMonkey/Random.swift
@@ -21,7 +21,7 @@ struct Random {
     }
 
     init(seed: UInt32) {
-        self.init(seed: 0, sequence: 0)
+        self.init(seed: seed, sequence: 0)
     }
 
     init(seed: UInt32, sequence: UInt32) {


### PR DESCRIPTION
Noticed the pattern always was the same in the tests, whatever seed I used.
Saw that the seed returned from Random.swift never changed.
Looked into Random.swift and found this.
Works like a charm now.